### PR TITLE
add downloadURL parameter for keadm join

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -95,6 +95,8 @@ const (
 	// eg.  "/tmp/kubeedge" or "/etc/kubeedge" by default
 	TarballPath = "tarballpath"
 
+	DownloadURL = "downloadurl"
+
 	StrCheck    = "check"
 	StrDiagnose = "diagnose"
 

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -48,6 +48,7 @@ type JoinOptions struct {
 	QuicPort              string
 	TunnelPort            string
 	CGroupDriver          string
+	DownloadURL           string
 }
 
 type CheckOptions struct {

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -129,6 +129,9 @@ func addJoinOtherFlags(cmd *cobra.Command, joinOptions *types.JoinOptions) {
 
 	cmd.Flags().StringVar(&joinOptions.TarballPath, types.TarballPath, joinOptions.TarballPath,
 		"Use this key to set the temp directory path for KubeEdge tarball, if not exist, download it")
+
+	cmd.Flags().StringVar(&joinOptions.DownloadURL, types.DownloadURL, joinOptions.DownloadURL,
+		"The domain of URL to dowanload kubeedge, checksum and service file")
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.
@@ -184,6 +187,7 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 		TunnelPort:            joinOptions.TunnelPort,
 		CGroupDriver:          joinOptions.CGroupDriver,
 		TarballPath:           joinOptions.TarballPath,
+		DownloadURL:           joinOptions.DownloadURL,
 	}
 
 	toolList["MQTT"] = &util.MQTTInstTool{}

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -408,7 +408,7 @@ func installKubeEdge(options types.InstallOptions, arch string, version semver.V
 		if err := retryDownload(filename, checksumFilename, version, options.TarballPath); err != nil {
 			return err
 		}
-		return nil
+		//return nil
 	}
 
 	if err := downloadServiceFile(options.ComponentType, version, KubeEdgePath); err != nil {

--- a/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
@@ -47,6 +47,7 @@ type KubeEdgeInstTool struct {
 	TunnelPort            string
 	CGroupDriver          string
 	TarballPath           string
+	DownloadURL           string
 }
 
 func CopyFile(pathSrc, pathDst string) {
@@ -77,6 +78,11 @@ func (ku *KubeEdgeInstTool) InstallTools() error {
 	opts := &types.InstallOptions{
 		TarballPath:   ku.TarballPath,
 		ComponentType: types.EdgeCore,
+	}
+
+	if ku.DownloadURL != "" {
+		KubeEdgeDownloadURL = fmt.Sprintf("%s/releases/download", ku.DownloadURL)
+		ServiceFileURLFormat = fmt.Sprintf("%s/releases/service/%s/%s", ku.DownloadURL, "%s", "%s")
 	}
 
 	if ku.Region == "en" {


### PR DESCRIPTION
1、Add downloadURL parameter for keadm join,which can change the default url of qingcloud
2、Comment a return statement,which will skip the processes after downloading kubeedge tarball including downloadServiceFile & untarAndMove kubeedge binary